### PR TITLE
Use final cats version, instead of MF

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,6 +14,6 @@ scalacOptions ++= Seq(
   "-Ypartial-unification" // allow the compiler to unify type constructors of different arities
 )
 
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-MF"
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0"
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")


### PR DESCRIPTION
Chapter 2.10.2 Invariant in Cats of ["Scala with Cats"](https://github.com/underscoreio/advanced-scala) seems to be relying on cats `1.0.0`, while this template is still locked to `1.0.0-MF`, which creates some issues (see https://github.com/underscoreio/advanced-scala/issues/129).

Since this template is recommended in a book, I think it would be fair to update it too. I did not do further examples, but everything I tried up to this chapter seems to be working fine with `1.0.0`.