### PR TITLE
Fixed the infamous "unused import" error

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,6 +14,8 @@ scalacOptions ++= Seq(
   "-Ypartial-unification" // allow the compiler to unify type constructors of different arities
 )
 
+scalacOptions in (Compile, console) ++= Seq("-Ywarn-unused:-imports")
+
 libraryDependencies += "org.typelevel" %% "cats-core" % "1.4.0"
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")


### PR DESCRIPTION
* Removed the warning about unused imports in the Sbt console
* Together with fatal warnings this leads to really strange behaviour in the console: the import will always fail because it will instantaneously trigger a fatal "unused import" warning